### PR TITLE
Identification should be always on

### DIFF
--- a/nextgisweb/webmap/amd/ngw-webmap/Display.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/Display.js
@@ -420,35 +420,6 @@ define([
             this._startupDeferred.resolve();
         },
 
-        addTool: function (tool) {
-            var btn = new ToggleButton({
-                label: tool.label,
-                showLabel: false,
-                iconClass: tool.iconClass
-            }).placeAt(this.mapToolbar.items);
-
-            tool.toolbarBtn = btn;
-
-            this.tools.push(tool);
-
-            var display = this;
-            btn.watch("checked", function (attr, oldVal, newVal) {
-                if (newVal) {
-                    // При включении инструмента все остальные инструменты
-                    // выключаем, а этот включаем
-                    array.forEach(display.tools, function (t) {
-                        if (t != tool && t.toolbarBtn.get("checked")) {
-                            t.toolbarBtn.set("checked", false);
-                        }
-                    });
-                    tool.activate();
-                } else {
-                    // При выключении остальные инструменты не трогаем
-                    tool.deactivate();
-                }
-            });
-        },
-
         _itemStoreSetup: function () {
             var itemConfigById = {};
 
@@ -686,11 +657,11 @@ define([
         },
 
         _toolsSetup: function () {
-            this.addTool(new ToolZoom({display: this, out: false}));
-            this.addTool(new ToolZoom({display: this, out: true}));
+            this.mapToolbar.items.addTool(new ToolZoom({display: this, out: false}), 'zoomingIn');
+            this.mapToolbar.items.addTool(new ToolZoom({display: this, out: true}), 'zoomingOut');
 
-            this.addTool(new ToolMeasure({display: this, type: "LineString"}));
-            this.addTool(new ToolMeasure({display: this, type: "Polygon"}));
+            this.mapToolbar.items.addTool(new ToolMeasure({display: this, type: "LineString"}), 'measuringLength');
+            this.mapToolbar.items.addTool(new ToolMeasure({display: this, type: "Polygon"}), 'measuringArea');
         },
 
         _pluginsSetup: function () {

--- a/nextgisweb/webmap/amd/ngw-webmap/Display.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/Display.js
@@ -275,7 +275,9 @@ define([
 
             // Загружаем закладки, когда кнопка будет готова
             this._postCreateDeferred.then(
-                function () { widget.loadBookmarks(); }
+                function () {
+                    widget.mapToolbar.items.loadBookmarks();
+                }
             ).then(undefined, function (err) { console.error(err); });
 
             // Выбранный элемент
@@ -445,46 +447,6 @@ define([
                     tool.deactivate();
                 }
             });
-        },
-
-        loadBookmarks: function () {
-            if (this.config.bookmarkLayerId) {
-                var store = new JsonRest({target: route.feature_layer.store({
-                    id: this.config.bookmarkLayerId
-                })});
-
-                var display = this;
-
-                store.query().then(
-                    function (data) {
-                        array.forEach(data, function (f) {
-                            display.mapToolbar.items.bookmarkMenu.addChild(new MenuItem({
-                                label: f.label,
-                                onClick: function () {
-                                    // Отдельно запрашиваем экстент объекта
-                                    xhr.get(route.feature_layer.store.item({
-                                        id: display.config.bookmarkLayerId,
-                                        feature_id: f.id
-                                    }), {
-                                        handleAs: "json",
-                                        headers: { "X-Feature-Box": true }
-                                    }).then(
-                                        function data(featuredata) {
-                                            display.map.olMap.getView().fit(
-                                                featuredata.box,
-                                                display.map.olMap.getSize()
-                                            );
-                                        }
-                                    );
-                                }
-                            }));
-                        });
-                    }
-                );
-            } else {
-                // Если слой с закладками не указан, то прячем кнопку
-                domStyle.set(this.bookmarkButton.domNode, "display", "none");
-            }
         },
 
         _itemStoreSetup: function () {

--- a/nextgisweb/webmap/amd/ngw-webmap/Display.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/Display.js
@@ -33,6 +33,7 @@ define([
     "ngw-pyramid/i18n!webmap",
     "ngw-pyramid/hbs-i18n",
     // tools
+    "ngw-webmap/MapToolbar",
     "./tool/Base",
     "./tool/Zoom",
     "./tool/Measure",
@@ -85,6 +86,7 @@ define([
     route,
     i18n,
     hbsI18n,
+    MapToolbar,
     ToolBase,
     ToolZoom,
     ToolMeasure,
@@ -421,7 +423,7 @@ define([
                 label: tool.label,
                 showLabel: false,
                 iconClass: tool.iconClass
-            }).placeAt(this.mapToolbar);
+            }).placeAt(this.mapToolbar.items);
 
             tool.toolbarBtn = btn;
 
@@ -456,7 +458,7 @@ define([
                 store.query().then(
                     function (data) {
                         array.forEach(data, function (f) {
-                            display.bookmarkMenu.addChild(new MenuItem({
+                            display.mapToolbar.items.bookmarkMenu.addChild(new MenuItem({
                                 label: f.label,
                                 onClick: function () {
                                     // Отдельно запрашиваем экстент объекта
@@ -591,13 +593,13 @@ define([
             // Обновление подписи центра карты
             this.map.watch("center", function (attr, oldVal, newVal) {
                 var pt = ol.proj.transform(newVal, widget.displayProjection, widget.lonlatProjection);
-                widget.centerLonNode.innerHTML = number.format(pt[0], {places: 3});
-                widget.centerLatNode.innerHTML = number.format(pt[1], {places: 3});
+                widget.mapToolbar.items.centerLonNode.innerHTML = number.format(pt[0], {places: 3});
+                widget.mapToolbar.items.centerLatNode.innerHTML = number.format(pt[1], {places: 3});
             });
 
             // Обновление подписи масштабного уровня
             this.map.watch("resolution", function (attr, oldVal, newVal) {
-                widget.scaleInfoNode.innerHTML = "1 : " + number.format(
+                widget.mapToolbar.items.scaleInfoNode.innerHTML = "1 : " + number.format(
                     widget.map.getScaleForResolution(
                         newVal,
                         widget.map.olMap.getView().getProjection().getMetersPerUnit()
@@ -636,7 +638,7 @@ define([
                 idx = idx + 1;
             }, this);
 
-            this.zoomToInitialExtentButton.on("click", function() {
+            this.mapToolbar.items.zoomToInitialExtentButton.on("click", function() {
                 widget._zoomToInitialExtent();
             });
 

--- a/nextgisweb/webmap/amd/ngw-webmap/MapStatesObserver.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/MapStatesObserver.js
@@ -44,29 +44,31 @@ define([
         },
 
         activateState: function (state) {
-            if (this._states.hasOwnProperty(state)) {
-                if (this._currentState) {
-                    this._states[this._currentState].control.deactivate();
-                }
-                this._states[state].control.activate();
-                this._currentState = state;
-                return true;
-            } else {
+            if (!this._states.hasOwnProperty(state)) {
                 return false;
             }
+
+            if (this._currentState) {
+                this._states[this._currentState].control.deactivate();
+
+            }
+            this._states[state].control.activate();
+            this._currentState = state;
+            return true;
         },
 
         deactivateState: function (state) {
-            if (this._states.hasOwnProperty(state)) {
-                this._states[state].control.deactivate();
-                this._currentState = null;
-                if (this._defaultState) {
-                    this.activateState(this._defaultState);
-                }
-                return true;
-            } else {
+            if (!this._states.hasOwnProperty(state) ||
+                state !== this._currentState) {
                 return false;
             }
+
+            this._states[state].control.deactivate();
+            this._currentState = null;
+            if (this._defaultState && this._defaultState !== state) {
+                this.activateState(this._defaultState);
+            }
+            return true;
         },
 
         setDefaultState: function (state, activate) {

--- a/nextgisweb/webmap/amd/ngw-webmap/MapStatesObserver.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/MapStatesObserver.js
@@ -1,0 +1,79 @@
+define([
+    'dojo/_base/declare',
+    'dojo/_base/array',
+    'ngw/utils/make-singleton'
+], function (declare, array, MakeSingleton) {
+    return MakeSingleton(declare('ngw-webmap.MapStatesObserver', [], {
+        _states: {},
+        _defaultState: null,
+        _currentState: null,
+
+        constructor: function (options) {
+            if (!options) {
+                return true;
+            }
+
+            if (options.states) {
+                array.forEach(options.states, function (stateItem) {
+                    this.addState(stateItem.state, stateItem.control);
+                }, this);
+            }
+
+            if (options.defaultState) {
+                this.setDefaultState(options.defaultState);
+            }
+        },
+
+        addState: function (state, control, activate) {
+
+            if (this._states.hasOwnProperty(state)) {
+                throw new Exception('State "' + state + '" already registered.');
+            }
+
+            this._states[state] = {
+                control: control
+            };
+
+            if (activate) {
+                this.activateState(state);
+            }
+        },
+
+        removeState: function (state) {
+            delete this._states[state];
+        },
+
+        activateState: function (state) {
+            if (this._states.hasOwnProperty(state)) {
+                if (this._currentState) {
+                    this._states[this._currentState].control.deactivate();
+                }
+                this._states[state].control.activate();
+                this._currentState = state;
+                return true;
+            } else {
+                return false;
+            }
+        },
+
+        deactivateState: function (state) {
+            if (this._states.hasOwnProperty(state)) {
+                this._states[state].control.deactivate();
+                this._currentState = null;
+                if (this._defaultState) {
+                    this.activateState(this._defaultState);
+                }
+                return true;
+            } else {
+                return false;
+            }
+        },
+
+        setDefaultState: function (state, activate) {
+            this._defaultState = state;
+            if (activate) {
+                this.activateState(state);
+            }
+        }
+    }));
+});

--- a/nextgisweb/webmap/amd/ngw-webmap/MapToolbar.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/MapToolbar.js
@@ -7,7 +7,9 @@ define([
 ], function (declare, i18n, hbsI18n, Toolbar, MapToolbarItems) {
     return declare([Toolbar], {
         postCreate: function () {
-            this.items = new MapToolbarItems();
+            this.items = new MapToolbarItems({
+                display: this.display
+            });
             this.items.placeAt(this.domNode);
         }
     });

--- a/nextgisweb/webmap/amd/ngw-webmap/MapToolbar.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/MapToolbar.js
@@ -1,0 +1,14 @@
+define([
+    'dojo/_base/declare',
+    'ngw-pyramid/i18n!webmap',
+    'ngw-pyramid/hbs-i18n',
+    'dijit/Toolbar',
+    'ngw-webmap/MapToolbarItems'
+], function (declare, i18n, hbsI18n, Toolbar, MapToolbarItems) {
+    return declare([Toolbar], {
+        postCreate: function () {
+            this.items = new MapToolbarItems();
+            this.items.placeAt(this.domNode);
+        }
+    });
+});

--- a/nextgisweb/webmap/amd/ngw-webmap/MapToolbarItems.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/MapToolbarItems.js
@@ -1,17 +1,71 @@
 define([
     'dojo/_base/declare',
+    'dojo/_base/array',
+    'dojo/_base/lang',
+    'dojo/store/JsonRest',
+    'dojo/request/xhr',
+    'dojo/dom-style',
     'dijit/_WidgetBase',
     'dijit/_TemplatedMixin',
     'dijit/_WidgetsInTemplateMixin',
+    'dijit/MenuItem',
     'dojo/text!./template/MapToolbarItems.hbs',
+    'ngw/route',
     'ngw-pyramid/i18n!webmap',
     'ngw-pyramid/hbs-i18n',
     'dijit/form/DropDownButton',
     'dijit/form/Button',
     'dijit/ToolbarSeparator'
-], function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
-             template, i18n, hbsI18n) {
+], function (declare, array, lang, JsonRest, xhr, domStyle,
+             _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
+             MenuItem, template, route, i18n, hbsI18n) {
     return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
-        templateString: hbsI18n(template, i18n)
+        templateString: hbsI18n(template, i18n),
+
+        constructor: function (options) {
+            this.display = options.display;
+        },
+
+        loadBookmarks: function () {
+            if (this.display.config.bookmarkLayerId) {
+                var store = new JsonRest({
+                    target: route.feature_layer.store({
+                        id: this.display.config.bookmarkLayerId
+                    })
+                });
+
+                var display = this.display;
+
+                store.query().then(
+                    function (data) {
+                        array.forEach(data, function (f) {
+                            display.mapToolbar.items.bookmarkMenu.addChild(new MenuItem({
+                                label: f.label,
+                                onClick: function () {
+                                    // Отдельно запрашиваем экстент объекта
+                                    xhr.get(route.feature_layer.store.item({
+                                        id: display.config.bookmarkLayerId,
+                                        feature_id: f.id
+                                    }), {
+                                        handleAs: "json",
+                                        headers: {"X-Feature-Box": true}
+                                    }).then(
+                                        function data(featuredata) {
+                                            display.map.olMap.getView().fit(
+                                                featuredata.box,
+                                                display.map.olMap.getSize()
+                                            );
+                                        }
+                                    );
+                                }
+                            }));
+                        });
+                    }
+                );
+            } else {
+                // Если слой с закладками не указан, то прячем кнопку
+                domStyle.set(this.bookmarkButton.domNode, "display", "none");
+            }
+        }
     });
 });

--- a/nextgisweb/webmap/amd/ngw-webmap/MapToolbarItems.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/MapToolbarItems.js
@@ -9,21 +9,24 @@ define([
     'dijit/_TemplatedMixin',
     'dijit/_WidgetsInTemplateMixin',
     'dijit/MenuItem',
+    'dijit/form/ToggleButton',
     'dojo/text!./template/MapToolbarItems.hbs',
     'ngw/route',
     'ngw-pyramid/i18n!webmap',
     'ngw-pyramid/hbs-i18n',
+    'ngw-webmap/MapStatesObserver',
     'dijit/form/DropDownButton',
     'dijit/form/Button',
     'dijit/ToolbarSeparator'
 ], function (declare, array, lang, JsonRest, xhr, domStyle,
              _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
-             MenuItem, template, route, i18n, hbsI18n) {
+             MenuItem, ToggleButton, template, route, i18n, hbsI18n, MapStatesObserver) {
     return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
         templateString: hbsI18n(template, i18n),
 
         constructor: function (options) {
             this.display = options.display;
+            this.mapStates = MapStatesObserver.getInstance();
         },
 
         loadBookmarks: function () {
@@ -72,6 +75,38 @@ define([
                     );
                 }
             ));
+        },
+
+        addTool: function (tool, state) {
+            var control = new ToggleButton({
+                label: tool.label,
+                showLabel: false,
+                iconClass: tool.iconClass,
+                tool: tool,
+                state: state,
+                onChange: lang.hitch(this, function(checked){
+                    if (checked) {
+                        this.mapStates.activateState(control.state);
+                    } else {
+                        this.mapStates.deactivateState(control.state);
+                    }
+
+                })
+            }).placeAt(this);
+            tool.toolbarBtn = control;
+
+            control.activate = function () {
+                this.set('checked', true);
+                this.tool.activate();
+            };
+
+            control.deactivate = function () {
+                this.set('checked', false);
+                this.tool.deactivate();
+            };
+
+            this.mapStates.addState(state, control, false);
         }
+
     });
 });

--- a/nextgisweb/webmap/amd/ngw-webmap/MapToolbarItems.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/MapToolbarItems.js
@@ -1,0 +1,17 @@
+define([
+    'dojo/_base/declare',
+    'dijit/_WidgetBase',
+    'dijit/_TemplatedMixin',
+    'dijit/_WidgetsInTemplateMixin',
+    'dojo/text!./template/MapToolbarItems.hbs',
+    'ngw-pyramid/i18n!webmap',
+    'ngw-pyramid/hbs-i18n',
+    'dijit/form/DropDownButton',
+    'dijit/form/Button',
+    'dijit/ToolbarSeparator'
+], function (declare, _WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin,
+             template, i18n, hbsI18n) {
+    return declare([_WidgetBase, _TemplatedMixin, _WidgetsInTemplateMixin], {
+        templateString: hbsI18n(template, i18n)
+    });
+});

--- a/nextgisweb/webmap/amd/ngw-webmap/plugin/FeatureLayer.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/plugin/FeatureLayer.js
@@ -22,7 +22,8 @@ define([
     "dijit/popup",
     "put-selector/put",
     "ngw/route",
-    "./../tool/Identify"
+    "ngw-webmap/MapStatesObserver",
+    "ngw-webmap/tool/Identify"
 ], function (
     declare,
     _PluginBase,
@@ -46,6 +47,7 @@ define([
     popup,
     put,
     route,
+    MapStatesObserver,
     Identify
 ) {
     var MAX_SEARCH_RESULTS = 15;
@@ -158,11 +160,14 @@ define([
             if (this.display.itemMenu) {
                 this.display.itemMenu.addChild(this.menuItem);
             }
-            this.display.addTool(this.tool);
 
-            if (this.display.infoNode) {
-                new ToolbarSeparator().placeAt(this.display.infoNode, 'first');
-                this.tbSearch.placeAt(this.display.infoNode, 'first');
+            var mapStates = MapStatesObserver.getInstance();
+            mapStates.addState('identifying', this.tool);
+            mapStates.setDefaultState('identifying', true);
+
+            if (this.display.mapToolbar.items.infoNode) {
+                new ToolbarSeparator().placeAt(this.display.mapToolbar.items.infoNode, 'first');
+                this.tbSearch.placeAt(this.display.mapToolbar.items.infoNode, 'first');
             }
         },
 

--- a/nextgisweb/webmap/amd/ngw-webmap/plugin/FeatureLayer.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/plugin/FeatureLayer.js
@@ -165,7 +165,7 @@ define([
             mapStates.addState('identifying', this.tool);
             mapStates.setDefaultState('identifying', true);
 
-            if (this.display.mapToolbar.items.infoNode) {
+            if (this.display.mapToolbar && this.display.mapToolbar.items.infoNode) {
                 new ToolbarSeparator().placeAt(this.display.mapToolbar.items.infoNode, 'first');
                 this.tbSearch.placeAt(this.display.mapToolbar.items.infoNode, 'first');
             }

--- a/nextgisweb/webmap/amd/ngw-webmap/template/Display.hbs
+++ b/nextgisweb/webmap/amd/ngw-webmap/template/Display.hbs
@@ -26,7 +26,7 @@
                     <!-- Тулбар над картой -->
                     <div data-dojo-attach-point="mapToolbar"
                         data-dojo-type="ngw-webmap/MapToolbar"
-                        data-dojo-props="region: 'top'">
+                        data-dojo-props="region: 'top', display: this">
                     </div>
 
                     <div data-dojo-attach-point="mapPane"

--- a/nextgisweb/webmap/amd/ngw-webmap/template/Display.hbs
+++ b/nextgisweb/webmap/amd/ngw-webmap/template/Display.hbs
@@ -25,49 +25,8 @@
 
                     <!-- Тулбар над картой -->
                     <div data-dojo-attach-point="mapToolbar"
-                        data-dojo-type="dijit/Toolbar"
+                        data-dojo-type="ngw-webmap/MapToolbar"
                         data-dojo-props="region: 'top'">
-
-                        <div style="padding: 0 4px; float: right;">
-
-                            <div data-dojo-attach-point="bookmarkButton"
-                                data-dojo-type="dijit/form/DropDownButton"
-                                data-dojo-props="label: '{{gettext 'Bookmarks'}}', iconClass: 'dijitIconBookmark'">
-
-                                <div data-dojo-attach-point="bookmarkMenu"
-                                    data-dojo-type="dijit/Menu">
-                                </div>
-
-                            </div>
-                        </div>
-
-                        <!-- Распорка по высоте -->
-                        <div data-dojo-type="dijit/form/Button" style="width: 0;">&nbsp;</div>
-
-                        <div data-dojo-attach-point="zoomToInitialExtentButton"
-                            data-dojo-type="dijit/form/Button"
-                            data-dojo-props="iconClass: 'iconArrowInOut', label: '{{gettext 'Initial extent'}}', showLabel: false">
-                        </div>
-
-                        <div data-dojo-type="dijit/ToolbarSeparator"></div>
-
-                        <div data-dojo-attach-point="infoNode"
-                            style="display: inline-block; vertical-align: middle; float: right; padding: 0 4px;">
-
-                            <div data-dojo-type="dijit/form/Button" style="width: 0;">&nbsp;</div>
-
-                            <span style="color: #999">{{gettext 'Longitude'}}</span>
-                            <span data-dojo-attach-point="centerLonNode"></span>
-
-                            <span style="color: #999">{{gettext 'Latitude'}}</span>
-                            <span data-dojo-attach-point="centerLatNode"></span>
-
-                            <span style="color: #999">{{gettext 'Scale'}}</span>
-                            <span data-dojo-attach-point="scaleInfoNode"></span>
-
-                        </div>
-
-
                     </div>
 
                     <div data-dojo-attach-point="mapPane"

--- a/nextgisweb/webmap/amd/ngw-webmap/template/MapToolbarItems.hbs
+++ b/nextgisweb/webmap/amd/ngw-webmap/template/MapToolbarItems.hbs
@@ -1,0 +1,36 @@
+<div>
+    <div style="padding: 0 4px; float: right;">
+        <div data-dojo-attach-point="bookmarkButton"
+             data-dojo-type="dijit/form/DropDownButton"
+             data-dojo-props="label: '{{gettext 'Bookmarks'}}', iconClass: 'dijitIconBookmark'">
+            <div data-dojo-attach-point="bookmarkMenu"
+                 data-dojo-type="dijit/Menu">
+            </div>
+        </div>
+    </div>
+
+    <!-- Распорка по высоте -->
+    <div data-dojo-type="dijit/form/Button" style="width: 0;">&nbsp;</div>
+
+    <div data-dojo-attach-point="zoomToInitialExtentButton"
+         data-dojo-type="dijit/form/Button"
+         data-dojo-props="iconClass: 'iconArrowInOut', label: '{{gettext 'Initial extent'}}', showLabel: false">
+    </div>
+
+    <div data-dojo-type="dijit/ToolbarSeparator"></div>
+
+    <div data-dojo-attach-point="infoNode"
+         style="display: inline-block; vertical-align: middle; float: right; padding: 0 4px;">
+
+        <div data-dojo-type="dijit/form/Button" style="width: 0;">&nbsp;</div>
+
+        <span style="color: #999">{{gettext 'Longitude'}}</span>
+        <span data-dojo-attach-point="centerLonNode"></span>
+
+        <span style="color: #999">{{gettext 'Latitude'}}</span>
+        <span data-dojo-attach-point="centerLatNode"></span>
+
+        <span style="color: #999">{{gettext 'Scale'}}</span>
+        <span data-dojo-attach-point="scaleInfoNode"></span>
+    </div>
+</div>

--- a/nextgisweb/webmap/amd/ngw-webmap/tool/Identify.js
+++ b/nextgisweb/webmap/amd/ngw-webmap/tool/Identify.js
@@ -74,7 +74,7 @@ define([
             evt.preventDefault();
         }
         return true;
-    }
+    };
 
     var Widget = declare([BorderContainer], {
         style: "width: 100%; height: 100%",


### PR DESCRIPTION
* part of functionality map toolbar items was moved to MapToolbar and MapToolbarItems modules (loadBookmarks, addTool etc.)
* was added MapStatesObserver, which manages of map states. Now, current map state this is one of toolbar button state or Identify tool state. Identify tool state was marked as default map state. 
* implemented https://github.com/nextgis/nextgisweb/issues/133

Demo is available [here](http://176.9.38.120/ngw-karavanjo-demo/resource/1/display?base=osm-mapnik&lon=23.4850&lat=52.1575&angle=0&zoom=12&styles=9,3).