### PR TITLE
#650 hide white input from map when info

### DIFF
--- a/nextgisweb/pyramid/amd/ngw-pyramid/CopyButton/CopyButton.css
+++ b/nextgisweb/pyramid/amd/ngw-pyramid/CopyButton/CopyButton.css
@@ -12,6 +12,8 @@
     left:0;
     top:0;
     z-index: -1000;
+    display: none;
+    opacity: 0;
 }
 
 .copy-button.activated .copy-button__icon{

--- a/nextgisweb/pyramid/amd/ngw-pyramid/CopyButton/CopyButton.js
+++ b/nextgisweb/pyramid/amd/ngw-pyramid/CopyButton/CopyButton.js
@@ -56,6 +56,7 @@ define([
             var widget = this;
 
             this.targetInput.value = this.target["" + this.targetAttribute];
+            this.targetInput.style.display = 'block';
             this.targetInput.select();
 
             try {
@@ -63,7 +64,10 @@ define([
                 widget.updateTooltip(widget.hintText.variants.success);
             } catch (err) {
                 widget.updateTooltip(widget.hintText.variants.error);
+            } finally {
+                this.targetInput.style.display = 'none';
             }
+            
         },
         updateTooltip: function(message){
             var widget = this;


### PR DESCRIPTION
input is needed to copy coordinates to the buffer; must be visible; now shows when the `copy` button pressed