### PR TITLE
Fix lib version for py2.7 support

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ requires = [
     'pillow==5.4.1',
     'lxml==4.3.0',
     'passlib==1.7.1',
-    'OWSLib>=0.17.1',
+    'OWSLib==0.17.1',
     'requests[security]==2.21.0',
     'babel==2.6.0',
     'minio==4.0.10',


### PR DESCRIPTION
Prevent [dropping](https://github.com/geopython/OWSLib/commit/430342c024f74d70a6cf78d1af810e803822997d#diff-6d09c9faa13634924a658ca3377cb098) python2 support