### PR TITLE
fix output string

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from subprocess import check_output, CalledProcessError
 from setuptools import setup, find_packages
 
 try:
-    gv = check_output(['gdal-config', '--version']).strip()
+    gv = check_output(['gdal-config', '--version'], universal_newlines=True).strip()
 except CalledProcessError:
     gv = None
 


### PR DESCRIPTION
Remove 'b' for prevent this:
ERROR: No matching distribution found for pygdal==**b**'2.4.0'.* (from nextgisweb==3.1)