### PR TITLE
prepare lambdas for py3

### DIFF
--- a/nextgisweb/__init__.py
+++ b/nextgisweb/__init__.py
@@ -48,7 +48,7 @@ def pkginfo():
 
     return dict(
         components=dict(map(
-            lambda (i): (i, "nextgisweb.%s" % i),
+            lambda i: (i, "nextgisweb.%s" % i),
             components)
         )
     )

--- a/nextgisweb/feature_layer/api.py
+++ b/nextgisweb/feature_layer/api.py
@@ -552,7 +552,7 @@ def store_collection(layer, request):
 
     field_prefix = json.loads(
         urllib.unquote(request.headers.get('x-field-prefix', '""')))
-    pref = lambda (f): field_prefix + f
+    pref = lambda f: field_prefix + f
 
     field_list = json.loads(
         urllib.unquote(request.headers.get('x-field-list', "[]")))

--- a/nextgisweb/feature_layer/view.py
+++ b/nextgisweb/feature_layer/view.py
@@ -227,4 +227,4 @@ def setup_pyramid(comp, config):
     Resource.__psection__.register(
         key='fields', title=_(u"Attributes"),
         template="nextgisweb:feature_layer/template/section_fields.mako",
-        is_applicable=lambda (obj): IFeatureLayer.providedBy(obj))
+        is_applicable=lambda obj: IFeatureLayer.providedBy(obj))

--- a/nextgisweb/psection.py
+++ b/nextgisweb/psection.py
@@ -25,7 +25,7 @@ class PageSections(object):
 
     def __iter__(self):
         items = list(self._items)
-        items.sort(key=lambda (itm): itm.priority)
+        items.sort(key=lambda itm: itm.priority)
         return items.__iter__()
 
     def register(self, **kwargs):

--- a/nextgisweb/pyramid/__init__.py
+++ b/nextgisweb/pyramid/__init__.py
@@ -115,7 +115,7 @@ class PyramidComponent(Component):
 
         # Access to Env through request.env
         config.add_request_method(
-            lambda (req): self._env, 'env',
+            lambda req: self._env, 'env',
             property=True)
 
         config.include(pyramid_tm)

--- a/nextgisweb/resource/model.py
+++ b/nextgisweb/resource/model.py
@@ -177,7 +177,7 @@ class Resource(Base):
         mask = set()
 
         for res in tuple(self.parents) + (self, ):
-            rules = filter(lambda (rule): (
+            rules = filter(lambda rule: (
                 (rule.propagate or res == self)
                 and rule.cmp_identity(self.identity)  # NOQA: W503
                 and rule.cmp_user(user)),  # NOQA: W503

--- a/nextgisweb/resource/view.py
+++ b/nextgisweb/resource/view.py
@@ -221,7 +221,7 @@ def setup_pyramid(comp, config):
     _route('schema', 'schema', client=()).add_view(schema)
 
     _route('root', '').add_view(
-        lambda (r): httpexceptions.HTTPFound(
+        lambda r: httpexceptions.HTTPFound(
             r.route_url('resource.show', id=0)))
 
     _resource_route('show', r'{id:\d+}', client=('id', )).add_view(show)
@@ -320,7 +320,7 @@ def setup_pyramid(comp, config):
                         'resource.json', id=args.obj.id))
 
         def _url(self, cls):
-            return lambda (args): args.request.route_url(
+            return lambda args: args.request.route_url(
                 'resource.create', id=args.obj.id,
                 _query=dict(cls=cls))
 

--- a/nextgisweb/vector_layer/model.py
+++ b/nextgisweb/vector_layer/model.py
@@ -240,7 +240,7 @@ class TableInfo(object):
             db.Column('geom', ga.Geometry(
                 dimension=2, srid=self.srs_id,
                 geometry_type=geom_fldtype)),
-            *map(lambda (fld): db.Column(fld.key, _FIELD_TYPE_2_DB[
+            *map(lambda fld: db.Column(fld.key, _FIELD_TYPE_2_DB[
                 fld.datatype]), self.fields)
         )
 
@@ -660,7 +660,7 @@ def _set_encoding(encoding):
                 # Wrapper for other GDAL versions
                 return strdecode
 
-            return lambda (x): x
+            return lambda x: x
 
         def __exit__(self, type, value, traceback):
 
@@ -689,7 +689,7 @@ class _source_attr(SP):
 
         return ogrlayer
 
-    def _ogrlayer(self, obj, ogrlayer, recode=lambda (a): a):
+    def _ogrlayer(self, obj, ogrlayer, recode=lambda a: a):
         if ogrlayer.GetSpatialRef() is None:
             raise VE(_("Layer doesn't contain coordinate system information."))
 

--- a/nextgisweb/views/model_controller.py
+++ b/nextgisweb/views/model_controller.py
@@ -26,7 +26,7 @@ class ModelController(object):
         self.client = client
 
     def includeme(self, config):
-        route = lambda (s): self.route_prefix + '.' + s
+        route = lambda s: self.route_prefix + '.' + s
 
         config.add_route(route('create'), self.url_base + '/create',
                          client=self.client_base)

--- a/nextgisweb/webmap/view.py
+++ b/nextgisweb/webmap/view.py
@@ -181,7 +181,7 @@ def setup_pyramid(comp, config):
                     self._url())
 
         def _url(self):
-            return lambda (args): args.request.route_url(
+            return lambda args: args.request.route_url(
                 'webmap.display', id=args.obj.id)
 
     WebMap.__dynmenu__.add(DisplayMenu())


### PR DESCRIPTION
Рarentheses in `lambda (x): x` are not allowed for py3 and are optional for py2